### PR TITLE
Fix Docker containers and update Ruby version

### DIFF
--- a/.sh/m1-install-nokogiri.sh
+++ b/.sh/m1-install-nokogiri.sh
@@ -1,0 +1,12 @@
+#!/bin/zsh
+
+brew install libxml2 libxslt
+
+cd ../backend
+
+bundle lock --add-platform x86_64-linux
+bundle install
+
+gem install nokogiri --platform=ruby -- --use-system-libraries
+
+cd ../.sh

--- a/.sh/m1-rebuild-docker.sh
+++ b/.sh/m1-rebuild-docker.sh
@@ -1,0 +1,22 @@
+#!/bin/zsh
+
+docker-compose down
+
+docker rmi team-snap-mega-tournament-backend
+
+chmod +x ./m1-update-rb-version.sh
+chmod +x ./m1-install-nokogiri.sh
+
+./m1-update-rb-version.sh
+./m1-install-nokogiri.sh
+
+docker-compose build
+
+docker-compose run frontend yarn
+docker-compose run backend bundle exec rake db:create
+
+docker-compose up -d
+
+open http://localhost:80
+
+cd ..

--- a/.sh/m1-update-rb-version.sh
+++ b/.sh/m1-update-rb-version.sh
@@ -1,0 +1,23 @@
+#!/bin/zsh
+
+cd ../backend
+
+RB_CURRENT_VERSION="2.7.1"
+RB_TARGET_VERSION="3.0.0"
+
+rbenv install $RB_TARGET_VERSION
+rbenv local $RB_TARGET_VERSION
+
+REPLACE_STR="s/$RB_CURRENT_VERSION/$RB_TARGET_VERSION/"
+
+DCR_FILE="./Dockerfile"
+GEM_FILE="./Gemfile"
+RBV_FILE="./.ruby-version"
+
+perl -pi.bak -e $REPLACE_STR $DCR_FILE $GEM_FILE $RBV_FILE
+
+rm $(ls -a | grep ".bak$")
+
+bundle update
+
+cd ../.sh

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,17 @@
 FROM ruby:2.7.1
+
 RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+
 WORKDIR /myapp/backend
+
 COPY Gemfile* ./
+
 RUN bundle install
+
 COPY . /myapp/backend
 
 ENV ENTRYKIT_VERSION 0.4.0
+
 RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
   && tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
   && rm entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.7.1
 
-RUN apt-get update -qq && apt-get install -y build-essential libpq-dev nodejs
+RUN apt-get update -qq \
+ && apt-get install -y build-essential libpq-dev nodejs
 
 WORKDIR /myapp/backend
 
@@ -10,15 +11,4 @@ RUN bundle install
 
 COPY . /myapp/backend
 
-ENV ENTRYKIT_VERSION 0.4.0
-
-RUN wget https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-  && tar -xvzf entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-  && rm entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz \
-  && mv entrykit /bin/entrykit \
-  && chmod +x /bin/entrykit \
-  && entrykit --symlink
-
-ENTRYPOINT [ \
-  "prehook", "ruby -v", "--", \
-  "prehook", "/myapp/backend/prehook", "--"]
+EXPOSE 3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   db:
     container_name: postgres
@@ -6,11 +6,10 @@ services:
     ports:
       - "5432:5432"
     environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_PASSWORD: changeme
     volumes:
       - ./tmp/db:/var/lib/postgresql/data
-    environment:
-      POSTGRES_HOST_AUTH_METHOD: trust
   backend:
     container_name: backend
     build: ./backend


### PR DESCRIPTION
To run the Docker containers properly on my Mac, I needed to do some updates on the project.

First, updating the Ruby version and removing Entrykit from the Dockerfile was necessary.

After that, I needed to update some gems to keep compatibility and get the ability to run the project on my Mac (M2 chip).

All the necessary steps to reproduce these updates can be found in the `.sh` root folder.


The Entrykit repo hasn't been getting new updates since 2016 (Please visit: https://github.com/progrium/entrykit).

All the articles on the internet that I found were talking about compatibility of the different versions, and recommending updating versions of the server language. So, I decided to cut off Entrykit and update the Ruby version. GH Issues: https://github.com/progrium/entrykit/issues/16